### PR TITLE
Feature: #15 UserType 변경 로직 구현

### DIFF
--- a/src/main/java/com/najasin/domain/user/entity/User.java
+++ b/src/main/java/com/najasin/domain/user/entity/User.java
@@ -84,7 +84,16 @@ public class User {
 		this.id = id;
 		this.oauth2Entity = oauth2Entity;
 		this.role = new ArrayList<>(List.of(Role.ROLE_MEMBER));
+
 		this.auditEntity = new AuditEntity();
+		userKeywords = new ArrayList<>();
+		answers = new ArrayList<>();
+		comments = new ArrayList<>();
+		userUserTypes = new ArrayList<>();
+	}
+
+	public void updateLastUserType(UserType lastUserType) {
+		this.lastUserType = lastUserType;
 	}
 
 	public List<SimpleGrantedAuthority> getRole() {

--- a/src/main/java/com/najasin/domain/userType/entity/UserType.java
+++ b/src/main/java/com/najasin/domain/userType/entity/UserType.java
@@ -4,6 +4,7 @@ import com.najasin.domain.userUserType.entity.UserUserType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +25,9 @@ public class UserType {
 
     @OneToMany(mappedBy = "userType")
     private List<UserUserType> userUserTypes;
+
+    @Builder
+    public UserType(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/najasin/domain/userType/repository/UserTypeRepository.java
+++ b/src/main/java/com/najasin/domain/userType/repository/UserTypeRepository.java
@@ -1,0 +1,11 @@
+package com.najasin.domain.userType.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.najasin.domain.userType.entity.UserType;
+
+public interface UserTypeRepository extends JpaRepository<UserType, Long> {
+	Optional<UserType> findByName(String name);
+}

--- a/src/main/java/com/najasin/domain/userType/service/UserTypeService.java
+++ b/src/main/java/com/najasin/domain/userType/service/UserTypeService.java
@@ -1,0 +1,21 @@
+package com.najasin.domain.userType.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.najasin.domain.userType.entity.UserType;
+import com.najasin.domain.userType.repository.UserTypeRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserTypeService {
+	private final UserTypeRepository userTypeRepository;
+
+	@Transactional(readOnly = true)
+	public UserType findByName(String name) {
+		return userTypeRepository.findByName(name).orElseThrow(EntityNotFoundException::new);
+	}
+}

--- a/src/main/java/com/najasin/domain/userUserType/controller/UserUserTypeController.java
+++ b/src/main/java/com/najasin/domain/userUserType/controller/UserUserTypeController.java
@@ -1,0 +1,35 @@
+package com.najasin.domain.userUserType.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.najasin.domain.user.entity.User;
+import com.najasin.domain.userUserType.dto.message.UserTypeMessage;
+import com.najasin.domain.userUserType.dto.request.UserTypeUpdateRequest;
+import com.najasin.domain.userUserType.dto.response.UserTypeResponse;
+import com.najasin.domain.userUserType.service.UserUserTypeService;
+import com.najasin.global.annotation.AuthorizeUser;
+import com.najasin.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/user/type")
+public class UserUserTypeController {
+	private final UserUserTypeService userUserTypeService;
+
+	@PutMapping
+	public ResponseEntity<ApiResponse<UserTypeResponse>> modify(@AuthorizeUser User user,
+		@RequestBody @Validated UserTypeUpdateRequest request) {
+		String updatedUserType = userUserTypeService.updateUserType(user, request.userType());
+
+		return ResponseEntity.ok(ApiResponse.createSuccessWithData(
+			UserTypeMessage.SUCCESS_UPDATE_USER_TYPE.getMsg(),
+			UserTypeResponse.of(updatedUserType)));
+	}
+}

--- a/src/main/java/com/najasin/domain/userUserType/dto/message/UserTypeMessage.java
+++ b/src/main/java/com/najasin/domain/userUserType/dto/message/UserTypeMessage.java
@@ -1,0 +1,12 @@
+package com.najasin.domain.userUserType.dto.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserTypeMessage {
+	SUCCESS_UPDATE_USER_TYPE("유저 타입이 변경됐습니다.");
+
+	private final String msg;
+}

--- a/src/main/java/com/najasin/domain/userUserType/dto/request/UserTypeUpdateRequest.java
+++ b/src/main/java/com/najasin/domain/userUserType/dto/request/UserTypeUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.najasin.domain.userUserType.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserTypeUpdateRequest(@NotBlank String userType) {
+}

--- a/src/main/java/com/najasin/domain/userUserType/dto/response/UserTypeResponse.java
+++ b/src/main/java/com/najasin/domain/userUserType/dto/response/UserTypeResponse.java
@@ -1,0 +1,8 @@
+package com.najasin.domain.userUserType.dto.response;
+
+public record UserTypeResponse(String userType) {
+
+	public static UserTypeResponse of(String userType) {
+		return new UserTypeResponse(userType);
+	}
+}

--- a/src/main/java/com/najasin/domain/userUserType/repository/UserUserTypeRepository.java
+++ b/src/main/java/com/najasin/domain/userUserType/repository/UserUserTypeRepository.java
@@ -1,0 +1,11 @@
+package com.najasin.domain.userUserType.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.najasin.domain.userUserType.entity.UserUserType;
+import com.najasin.domain.userUserType.entity.UserUserTypeId;
+
+@Repository
+public interface UserUserTypeRepository extends JpaRepository<UserUserType, UserUserTypeId> {
+}

--- a/src/main/java/com/najasin/domain/userUserType/service/UserUserTypeService.java
+++ b/src/main/java/com/najasin/domain/userUserType/service/UserUserTypeService.java
@@ -1,0 +1,42 @@
+package com.najasin.domain.userUserType.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.najasin.domain.user.entity.User;
+import com.najasin.domain.userType.entity.UserType;
+import com.najasin.domain.userType.service.UserTypeService;
+import com.najasin.domain.userUserType.entity.UserUserType;
+import com.najasin.domain.userUserType.repository.UserUserTypeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserUserTypeService {
+	private final UserTypeService userTypeService;
+	private final UserUserTypeRepository userUserTypeRepository;
+
+	@Transactional
+	public String updateUserType(User user, String userTypeName) {
+		UserType userType = userTypeService.findByName(userTypeName);
+
+		if (!checkAlreadyExist(user.getUserUserTypes(), userType)) {
+			save(user, userType);
+		}
+
+		user.updateLastUserType(userType);
+		return userTypeName;
+	}
+
+	@Transactional
+	public UserUserType save(User user, UserType userType) {
+		return userUserTypeRepository.save(new UserUserType(user, userType));
+	}
+
+	private boolean checkAlreadyExist(List<UserUserType> userUserTypes, UserType userType) {
+		return userUserTypes.stream().map(UserUserType::getUserType).toList().contains(userType);
+	}
+}

--- a/src/test/java/com/najasin/service/UserTypeServiceTest.java
+++ b/src/test/java/com/najasin/service/UserTypeServiceTest.java
@@ -1,0 +1,71 @@
+package com.najasin.service;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.najasin.domain.userType.entity.UserType;
+import com.najasin.domain.userType.repository.UserTypeRepository;
+import com.najasin.domain.userType.service.UserTypeService;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+public class UserTypeServiceTest {
+	@InjectMocks
+	private UserTypeService userTypeService;
+
+	@Mock
+	private UserTypeRepository userTypeRepository;
+
+	private UserType mockUserType;
+	private String userTypeName;
+
+	@BeforeEach
+	void setup() {
+		userTypeName = "test";
+		mockUserType = new UserType(userTypeName);
+	}
+
+	@AfterEach
+	void cleanup() {
+		userTypeRepository.deleteAll();;
+	}
+
+	@Test
+	@DisplayName("타입 이름으로 UserType을 찾는다.")
+	void findByNameSuccess() {
+		// given
+		given(userTypeRepository.findByName(userTypeName))
+			.willReturn(Optional.of(mockUserType));
+
+		// when
+		UserType userType = userTypeService.findByName(userTypeName);
+
+		// then
+		assertEquals(mockUserType, userType);
+	}
+
+	@Test
+	@DisplayName("타입 이름으로 UserType을 찾는 데 실패한다")
+	void findByNameFail() {
+		// given
+		given(userTypeRepository.findByName(userTypeName))
+			.willReturn(Optional.empty());
+
+		// then
+		assertThrows(EntityNotFoundException.class, () -> {
+			userTypeService.findByName(userTypeName);
+		});
+	}
+}

--- a/src/test/java/com/najasin/service/UserUserTypeServiceTest.java
+++ b/src/test/java/com/najasin/service/UserUserTypeServiceTest.java
@@ -1,0 +1,82 @@
+package com.najasin.service;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.najasin.domain.user.entity.Oauth2Entity;
+import com.najasin.domain.user.entity.User;
+import com.najasin.domain.userType.entity.UserType;
+import com.najasin.domain.userType.service.UserTypeService;
+import com.najasin.domain.userUserType.entity.UserUserType;
+import com.najasin.domain.userUserType.repository.UserUserTypeRepository;
+import com.najasin.domain.userUserType.service.UserUserTypeService;
+
+@ExtendWith(MockitoExtension.class)
+public class UserUserTypeServiceTest {
+	@InjectMocks
+	private UserUserTypeService userUserTypeService;
+
+	@Mock
+	private UserTypeService userTypeService;
+
+	@Mock
+	private UserUserTypeRepository userUserTypeRepository;
+
+	private User mockUser;
+	private UserType mockUserType;
+	private String userTypeName;
+	private UserUserType mockUserUserType;
+
+	@BeforeEach
+	void setup() {
+		Oauth2Entity oauth2Entity = Oauth2Entity.builder().build();
+		userTypeName = "test";
+		mockUser = new User("", oauth2Entity);
+		mockUserType = new UserType(userTypeName);
+		mockUserUserType = new UserUserType(mockUser, mockUserType);
+	}
+
+	@AfterEach
+	void cleanup() {
+		userUserTypeRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("유저와 유저 타입의 연관관계를 저장한다")
+	void save() {
+		// given
+		given(userUserTypeRepository.save(any()))
+			.willReturn(mockUserUserType);
+
+		// when
+		UserUserType userUserType = userUserTypeService.save(mockUser, mockUserType);
+
+		// then
+		assertEquals(userUserType, mockUserUserType);
+	}
+
+	@Test
+	@DisplayName("유저의 유저 타입을 변경한다.")
+	void updateUserType() {
+		// given
+		given(userTypeService.findByName(userTypeName))
+			.willReturn(mockUserType);
+
+		//when
+		String updatedTypeName = userUserTypeService.updateUserType(mockUser, userTypeName);
+
+		// then
+		assertEquals(updatedTypeName, userTypeName);
+	}
+}


### PR DESCRIPTION
> ### PR Introduce

- #15 

> ### Description

UserType 변경 로직을 구현한다.

**_예상 시나리오 (2023.08.17 기준)_**
- JFF일 때, DF로 변경
- DF일 때, JFF로 변경
- JFF와 DF에 대한 모든 데이터를 가지고 있을 때의 변경

> ### Core Features

```java
	@Transactional
	public String updateUserType(User user, String userTypeName) {
		UserType userType = userTypeService.findByName(userTypeName);

		if (!checkAlreadyExist(user.getUserUserTypes(), userType)) {
			save(user, userType);
		}

		user.updateLastUserType(userType);
		return userTypeName;
	}
```

> ### etc
