### PR TITLE
fix: #21 my-maunal 모든 키워드 받아오도록 수정

### DIFF
--- a/src/main/java/com/najasin/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/najasin/domain/keyword/service/KeywordService.java
@@ -1,0 +1,21 @@
+package com.najasin.domain.keyword.service;
+
+import com.najasin.domain.keyword.entity.Keyword;
+import com.najasin.domain.keyword.repository.KeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordService {
+    private final KeywordRepository keywordRepository;
+
+    @Transactional
+    public List<String> getAllKeywords() {
+        return keywordRepository.findAll().stream().map(Keyword::getName).toList();
+    }
+}

--- a/src/main/java/com/najasin/domain/user/controller/UserController.java
+++ b/src/main/java/com/najasin/domain/user/controller/UserController.java
@@ -8,6 +8,8 @@ import com.najasin.domain.character.CharacterService;
 import com.najasin.domain.character.dto.AllCharacterItems;
 import com.najasin.domain.character.dto.CharacterItems;
 import com.najasin.domain.comment.service.CommentService;
+import com.najasin.domain.keyword.repository.KeywordRepository;
+import com.najasin.domain.keyword.service.KeywordService;
 import com.najasin.domain.question.entity.QuestionType;
 import com.najasin.domain.question.service.QuestionService;
 import com.najasin.domain.user.dto.*;
@@ -44,6 +46,8 @@ public class UserController {
 	private final UserUserTypeService userUserTypeService;
 	private final UserKeywordService userKeywordService;
 	private final CharacterService characterService;
+	private final KeywordService keywordService;
+//	String userId = "63a47bcb-ebb1-4618-b357-fdd6681bd0fc";
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<?>> logout(@AccessToken String accessToken, @RefreshToken String refreshToken) {
@@ -146,13 +150,14 @@ public class UserController {
 	public ResponseEntity<ApiResponse<?>> getMyManual(
 			@PathVariable String userTypeName,
 			@AuthorizeUser User user
-
 	) {
 		Manual manual = new Manual();
-
+		String userId = user.getId();
 		if(!isNull(user)) {
 			manual.setNickname(user.getId());
 		}
+		manual.setBaseImage("https://picsum.photos/200/300?random=1");
+		manual.setExampleKeywords(keywordService.getAllKeywords());
 		manual.setBaseImage("https://picsum.photos/200/300?random=1");
 		manual.setCharacterItems(characterService.getAllCharacterItems().getCharacterItems());
 		manual.setQuestions(questionService.getQuestionByQuestionTypeAndUserType(QuestionType.FOR_USER, userTypeName));
@@ -188,6 +193,7 @@ public class UserController {
 			@PathVariable String userTypeName,
 			@AuthorizeUser User user
 	) {
+//		User user = userService.findById(userId);
 		String userId = user.getId();
 		Page page = new Page();
 

--- a/src/test/java/com/najasin/service/KeywordServiceTest.java
+++ b/src/test/java/com/najasin/service/KeywordServiceTest.java
@@ -1,0 +1,67 @@
+package com.najasin.service;
+
+import com.najasin.domain.answer.entity.Answer;
+import com.najasin.domain.answer.repository.AnswerRepository;
+import com.najasin.domain.answer.service.AnswerService;
+import com.najasin.domain.keyword.entity.Keyword;
+import com.najasin.domain.keyword.repository.KeywordRepository;
+import com.najasin.domain.keyword.service.KeywordService;
+import com.najasin.domain.question.entity.Question;
+import com.najasin.domain.question.entity.QuestionType;
+import com.najasin.domain.question.repository.QuestionRepository;
+import com.najasin.domain.user.dto.PageUpdateRequestDTO;
+import com.najasin.domain.user.entity.Oauth2Entity;
+import com.najasin.domain.user.entity.User;
+import com.najasin.domain.user.entity.enums.Provider;
+import com.najasin.domain.user.repository.UserRepository;
+import com.najasin.domain.userType.entity.UserType;
+import com.najasin.domain.userType.repository.UserTypeRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class KeywordServiceTest {
+    @InjectMocks
+    private KeywordService keywordService;
+
+    @Mock
+    private KeywordRepository keywordRepository;
+
+
+    @Test
+    @DisplayName("모든 키워드를 가져온다")
+    public void getAllKeywords() {
+        //given
+        List<String> keywords = new ArrayList<>();
+        keywords.add("키워드1");
+        keywords.add("키워드2");
+        keywords.add("키워드3");
+        List<Keyword> keywordList = new ArrayList<>();
+        keywordList.add(new Keyword(1L, "키워드1"));
+        keywordList.add(new Keyword(2L, "키워드2"));
+        keywordList.add(new Keyword(3L, "키워드3"));
+        given(keywordRepository.findAll()).willReturn(keywordList);
+        //when
+        List<String> getAllKeywords = keywordService.getAllKeywords();
+        //then
+        assertEquals(getAllKeywords, keywords);
+    }
+}


### PR DESCRIPTION
* feature: CharacterSet, Face, Body, Expression 도메인 추가

* feature: Keyword, UserType, UserKeyword 도메인 추가

* feature: Face, Body, Expression show_case, layout_case 분리

* feature: Answer, Comment, Question 도메인 추가

* refactor: 복합키 camel case화, Entity Class 생성자 제한

* feature: 유저 내적나사 service 추가

* fix: user entity에 userType 추가

* fix: keyword Entity에 percent를 origin과 others로 나눔

* feature: 타인이 키워드 퍼센트 기여를 위한 service 수정 및 테스트

* feature: 타적나사를 위한 service 구현

* fix(#17): 충돌 처리 후 에러 해결

* feature(#18): 타적나사 추가, 삭제 서비스 구현 및 테스트

* feature(#19): 프로필 수정 기능 서비스 작성 및 테스트 코드 작성

* feature(#20): 마이페이지 조회 api 구현

* feature(#20): 마이페이지 수정 api 구현

* fix(#20): User에 nickname 추가, profile 별 캐릭터 존재하도록 변경

* feature(#20): 마이페이지 조회, 수정(닉네임, 내적내사), 타인페이지 조회 구현

* feature(#20): 내 사용 설명서 생성 기능 구현

* feature(#20): 캐릭터 수정 기능 구현

* feature(#20): 타적나사 기능 구현

* feature(#20): 모든 캐릭터 가져오기 기능 구현

* feature(#20): 기능 테스트 코드 갖성

* fix(#20): 코멘트가 질문, 유저 별로 여러개 추가될 수 있도록 수정

* fix(#20): 코멘트 수정으로 인한 테스트 코드 수정

* fix(#20): 타적내사 요구사항 반영(response 변경)

* fix(#20): 내적나사 post 요구사항 반영(유저 정보 response에 담음)

* fix(#20): Entity lazy 로딩 설정

* fix(#20): 컨트롤러에 유저 인증 추가

* fix(#20): 겹치는 dto 수정 및 삭제

* fix(#21): cors에 로컬 환경 추가

* fix(#20): Comment 요구사항 반영(닉네임 추가)

* fix(#21): otherManual 요구사항 반영

* fix(#21): post 응답에 userId, userType 추가

* test(#21): 테스트 코드 작성

* fix(#21): 유저타입, 캐릭터 아이템 가져오기 수정

* fix(#34): prod 환경 ddl auto 수정

* fix(#21): 캐릭터 dto 수정

* fix(#21): example keywords 가져오도록 수정

* fix(#21): merge conflict 해결

* fix(#21): getAllKeywords 간략화

---------

> ### PR Introduce

> ### Description

> ### Core Features

```java
. . .
```

> ### Prev

```java
. . .
```

> ### Changed

```java
. . .
```

> ### etc
