### PR TITLE
Fix: #22 my_manual post 요청 다시 보낼 시 실패 응답 보냄, mypage 소유자 체크 수정

### DIFF
--- a/src/main/java/com/najasin/domain/manual/dto/message/ManualMessage.java
+++ b/src/main/java/com/najasin/domain/manual/dto/message/ManualMessage.java
@@ -9,6 +9,7 @@ public enum ManualMessage {
 	FIND_MY_MANUAL_SUCCESS("my manual 조회에 성공했습니다."),
 	CREATE_MY_MANUAL_SUCCESS("my manual 생성에 성공했습니다."),
 	FIND_OTHERS_MANUAL_SUCCESS("others manual 조회에 성공했습니다."),
-	CREATE_OTHERS_MANUAL_SUCCESS("others manual 생성에 성공했습니다.");
+	CREATE_OTHERS_MANUAL_SUCCESS("others manual 생성에 성공했습니다."),
+	CREATE_MY_MANUAL_FAIL("my manual 생성에 실패하였습니다.");
 	private final String msg;
 }

--- a/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
+++ b/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
@@ -96,7 +96,7 @@ public class UserUserTypeService {
 				.othersManualQAPairs(comments)
 				.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
 				.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
-				.isOwner(user.getId() == userId)
+				.isOwner(user.getId().equals(userId))
 				.build();
 	}
 

--- a/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
+++ b/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
@@ -69,41 +69,41 @@ public class UserUserTypeService {
 			userUserType.updateCharacter(characterService.findCharacterSetById(items.set()));
 		} else {
 			userUserType.updateCharacter(
-				isNull(items.face()) ? null : characterService.findFaceById(items.face()),
-				isNull(items.body()) ? null : characterService.findBodyById(items.body()),
-				isNull(items.expression()) ? null : characterService.findExpressionById(items.expression()));
+					isNull(items.face()) ? null : characterService.findFaceById(items.face()),
+					isNull(items.body()) ? null : characterService.findBodyById(items.body()),
+					isNull(items.expression()) ? null : characterService.findExpressionById(items.expression()));
 		}
 	}
 
 	@Transactional(readOnly = true)
 	public MyPageResponse getMyPage(User user, String userType, String userId) {
 		List<UserType> userTypes =
-			isNull(user) ? null : user.getUserUserTypes().stream().map(UserUserType::getUserType).toList();
+				isNull(user) ? null : user.getUserUserTypes().stream().map(UserUserType::getUserType).toList();
 		UserUserType userUserType = findByUserIdAndUserTypeName(userId, userType);
 		List<AnswerParam> answers = answerService.findByUserIdAndUserType(userId, userType)
-			.stream()
-			.map(Answer::toMyAnswerParam)
-			.toList();
+				.stream()
+				.map(Answer::toMyAnswerParam)
+				.toList();
 		List<UserKeyword> percents = userKeywordService.findByUserId(userId);
 		List<CommentParam> comments = commentService.mapToCommentParam(commentService.findAllByUserId(userId));
 
 		return MyPageResponse.builder()
-			.userTypes(isNull(userTypes) ? null : userTypes.stream().map(UserType::getName).toList())
-			.nickname(userUserType.getNickname())
-			.baseImage(baseImage)
-			.characterItems(userUserType.toMyCharacterItemsParam())
-			.myManualQAPair(answers)
-			.othersManualQAPairs(comments)
-			.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
-			.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
-			.isOwner(!isNull(user))
-			.build();
+				.userTypes(isNull(userTypes) ? null : userTypes.stream().map(UserType::getName).toList())
+				.nickname(userUserType.getNickname())
+				.baseImage(baseImage)
+				.characterItems(userUserType.toMyCharacterItemsParam())
+				.myManualQAPair(answers)
+				.othersManualQAPairs(comments)
+				.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
+				.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
+				.isOwner(user.getId() == userId)
+				.build();
 	}
 
 	@Transactional(readOnly = true)
 	public UserUserType findByUserIdAndUserTypeName(String userId, String userTypeName) {
 		return userUserTypeRepository.findByUserIdAndUserTypeName(userId, userTypeName)
-			.orElseThrow(EntityNotFoundException::new);
+				.orElseThrow(EntityNotFoundException::new);
 	}
 
 	private boolean checkAlreadyExist(List<UserUserType> userUserTypes, UserType userType) {

--- a/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
+++ b/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
@@ -96,7 +96,7 @@ public class UserUserTypeService {
 				.othersManualQAPairs(comments)
 				.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
 				.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
-				.isOwner(user.getId().equals(userId))
+				.isOwner((user == null) ? user.getId().equals(userId) : false)
 				.build();
 	}
 

--- a/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
+++ b/src/main/java/com/najasin/domain/user/service/UserUserTypeService.java
@@ -96,7 +96,7 @@ public class UserUserTypeService {
 				.othersManualQAPairs(comments)
 				.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
 				.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
-				.isOwner((user == null) ? user.getId().equals(userId) : false)
+				.isOwner(nonNull(user)&&user.getId().equals(userId))
 				.build();
 	}
 


### PR DESCRIPTION
> ### PR Introduce

> ### Description

> ### Core Features

```java
@PostMapping
	public ResponseEntity<ApiResponse<?>> saveMyManual(
			@AuthorizeUser User user,
			@PathVariable String userType,
			@RequestBody MyManualCreateRequest body) {
		try {
			userUserTypeService.findByUserIdAndUserTypeName(user.getId(), userType);
			return new ResponseEntity<>(
					createFail(CREATE_MY_MANUAL_FAIL.getMsg()),
					HttpStatus.CONFLICT);
		} catch (EntityNotFoundException e) {
			UserUserType saveUserType = userUserTypeService.save(user, userType, body.nickname());
			userUserTypeService.updateCharacter(saveUserType, body.characterItems());
			userUserTypeService.updateUserType(user, userType);


			List<Question> questions = questionService.findAllByIdList(body.getQuestionIdList());
			answerService.saveAll(body.answers(), questions, user);

			List<Keyword> keywords = keywordService.findAllByIdList(body.getKeywordIdList());
			userKeywordService.saveAll(body.keywordPercents(), keywords, user);


			return new ResponseEntity<>(
					createSuccessWithData(
							CREATE_MY_MANUAL_SUCCESS.getMsg(),
							JffMyManualCreateResponse.of(user.getId(), userType)),
					HttpStatus.CREATED
			);
		}
	}
}
```

이미 userUserType이 있는 경우에는 실패 응답을 보내도록 하였습니다.

> ### Prev

```java
@Transactional(readOnly = true)
	public MyPageResponse getMyPage(User user, String userType, String userId) {
		List<UserType> userTypes =
				isNull(user) ? null : user.getUserUserTypes().stream().map(UserUserType::getUserType).toList();
		UserUserType userUserType = findByUserIdAndUserTypeName(userId, userType);
		List<AnswerParam> answers = answerService.findByUserIdAndUserType(userId, userType)
				.stream()
				.map(Answer::toMyAnswerParam)
				.toList();
		List<UserKeyword> percents = userKeywordService.findByUserId(userId);
		List<CommentParam> comments = commentService.mapToCommentParam(commentService.findAllByUserId(userId));

		return MyPageResponse.builder()
				.userTypes(isNull(userTypes) ? null : userTypes.stream().map(UserType::getName).toList())
				.nickname(userUserType.getNickname())
				.baseImage(baseImage)
				.characterItems(userUserType.toMyCharacterItemsParam())
				.myManualQAPair(answers)
				.othersManualQAPairs(comments)
				.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
				.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
				.isOwner(isNull(user))
				.build();
	}
```

> ### Changed

```java
@Transactional(readOnly = true)
	public MyPageResponse getMyPage(User user, String userType, String userId) {
		List<UserType> userTypes =
				isNull(user) ? null : user.getUserUserTypes().stream().map(UserUserType::getUserType).toList();
		UserUserType userUserType = findByUserIdAndUserTypeName(userId, userType);
		List<AnswerParam> answers = answerService.findByUserIdAndUserType(userId, userType)
				.stream()
				.map(Answer::toMyAnswerParam)
				.toList();
		List<UserKeyword> percents = userKeywordService.findByUserId(userId);
		List<CommentParam> comments = commentService.mapToCommentParam(commentService.findAllByUserId(userId));

		return MyPageResponse.builder()
				.userTypes(isNull(userTypes) ? null : userTypes.stream().map(UserType::getName).toList())
				.nickname(userUserType.getNickname())
				.baseImage(baseImage)
				.characterItems(userUserType.toMyCharacterItemsParam())
				.myManualQAPair(answers)
				.othersManualQAPairs(comments)
				.originKeywordPercents(percents.stream().map(UserKeyword::toMyKeywordPercentParam).toList())
				.otherKeywordPercents(percents.stream().map(UserKeyword::toOthersKeywordPercentParam).toList())
				.isOwner(user.getId().equals(userId))
				.build();
	}
```

userId와 user의 아이디가 같은 경우에만 true를 반환하도록 하였습니다

> ### etc
