### PR TITLE
feature(#71): refresh token을 통한 access token 재발급 로직 구현

### DIFF
--- a/src/main/java/com/najasin/config/SecurityConfig.java
+++ b/src/main/java/com/najasin/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
 					new AntPathRequestMatcher("/swagger-ui/index.html"),
 					new AntPathRequestMatcher("/auth2/**"),
 					new AntPathRequestMatcher("/login/**"),
+					new AntPathRequestMatcher("/api/auth/accessToken"),
 					new AntPathRequestMatcher("/api/user/*/mypage", "GET"),
 					new AntPathRequestMatcher("/api/*/others-manual/**"),
 					new AntPathRequestMatcher("/api/characterItems")

--- a/src/main/java/com/najasin/domain/user/controller/AuthController.java
+++ b/src/main/java/com/najasin/domain/user/controller/AuthController.java
@@ -1,14 +1,22 @@
 package com.najasin.domain.user.controller;
 
+import static com.najasin.domain.user.dto.message.UserResponse.*;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.najasin.domain.user.dto.message.UserResponse;
+import com.najasin.domain.user.dto.response.AccessTokenGenerateResponse;
 import com.najasin.domain.user.service.UserService;
 import com.najasin.global.annotation.AccessToken;
 import com.najasin.global.annotation.RefreshToken;
 import com.najasin.global.response.ApiResponse;
+import com.najasin.security.jwt.exception.JwtBlackListException;
+import com.najasin.security.jwt.exception.JwtExpirationException;
+import com.najasin.security.jwt.exception.JwtNotSupportException;
+import com.najasin.security.jwt.exception.JwtWrongException;
+import com.najasin.security.jwt.exception.JwtWrongSignatureException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +34,20 @@ public class AuthController {
 		return new ResponseEntity<>(
 			ApiResponse.createSuccess(UserResponse.SUCCESS_LOGOUT.getMessage()),
 			HttpStatus.OK
+		);
+	}
+
+	@PostMapping("/accessToken")
+	public ResponseEntity<ApiResponse<AccessTokenGenerateResponse>> regenerateAccessToken(
+		@RefreshToken String refreshToken) throws JwtNotSupportException, JwtWrongSignatureException,
+		JwtExpirationException, JwtWrongException, JwtBlackListException {
+
+		String accessToken = userService.recreateAccessToken(refreshToken);
+		return new ResponseEntity<>(
+			ApiResponse.createSuccessWithData(
+				SUCCESS_RECREATE_ACCESS_TOKEN.getMessage(),
+				new AccessTokenGenerateResponse(accessToken)),
+			HttpStatus.CREATED
 		);
 	}
 }

--- a/src/main/java/com/najasin/domain/user/controller/AuthController.java
+++ b/src/main/java/com/najasin/domain/user/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.najasin.domain.user.dto.message.UserResponse;
 import com.najasin.domain.user.dto.response.AccessTokenGenerateResponse;
+import com.najasin.domain.user.service.AuthService;
 import com.najasin.domain.user.service.UserService;
 import com.najasin.global.annotation.AccessToken;
 import com.najasin.global.annotation.RefreshToken;
@@ -26,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 
 public class AuthController {
 	private final UserService userService;
+	private final AuthService authService;
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<?>> logout(@AccessToken String accessToken, @RefreshToken String refreshToken) {
@@ -42,7 +44,7 @@ public class AuthController {
 		@RefreshToken String refreshToken) throws JwtNotSupportException, JwtWrongSignatureException,
 		JwtExpirationException, JwtWrongException, JwtBlackListException {
 
-		String accessToken = userService.recreateAccessToken(refreshToken);
+		String accessToken = authService.recreateAccessToken(refreshToken);
 		return new ResponseEntity<>(
 			ApiResponse.createSuccessWithData(
 				SUCCESS_RECREATE_ACCESS_TOKEN.getMessage(),

--- a/src/main/java/com/najasin/domain/user/dto/message/UserResponse.java
+++ b/src/main/java/com/najasin/domain/user/dto/message/UserResponse.java
@@ -10,6 +10,7 @@ public enum UserResponse {
 	SUCCESS_UPDATE_NICKNAME("닉네임 수정에 성공하였습니다."),
 	SUCCESS_UPDATE_CHARACTER("캐릭터 수정에 성공하였습니다."),
 	SUCCESS_UPDATE_ANSWER("답변 수정에 성공하였습니다."),
-	SUCCESS_GET_MY_PAGE("마이 페이지 조회에 성공하였습니다.");
+	SUCCESS_GET_MY_PAGE("마이 페이지 조회에 성공하였습니다."),
+	SUCCESS_RECREATE_ACCESS_TOKEN("액세스 토큰 재발급에 성공하셨습니다.");
 	private final String message;
 }

--- a/src/main/java/com/najasin/domain/user/dto/response/AccessTokenGenerateResponse.java
+++ b/src/main/java/com/najasin/domain/user/dto/response/AccessTokenGenerateResponse.java
@@ -1,0 +1,4 @@
+package com.najasin.domain.user.dto.response;
+
+public record AccessTokenGenerateResponse(String accessToken) {
+}

--- a/src/main/java/com/najasin/domain/user/service/AuthService.java
+++ b/src/main/java/com/najasin/domain/user/service/AuthService.java
@@ -1,0 +1,32 @@
+package com.najasin.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.najasin.security.jwt.exception.JwtBlackListException;
+import com.najasin.security.jwt.exception.JwtExpirationException;
+import com.najasin.security.jwt.exception.JwtNotSupportException;
+import com.najasin.security.jwt.exception.JwtWrongException;
+import com.najasin.security.jwt.exception.JwtWrongSignatureException;
+import com.najasin.security.jwt.util.JwtProvider;
+import com.najasin.security.jwt.util.JwtValidator;
+import com.najasin.security.model.PrincipalUser;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	private final JwtValidator jwtValidator;
+	private final JwtProvider jwtProvider;
+
+	public String recreateAccessToken(String refreshToken) throws
+		JwtNotSupportException,
+		JwtWrongSignatureException,
+		JwtExpirationException,
+		JwtWrongException,
+		JwtBlackListException {
+		PrincipalUser principalUser = jwtValidator.getPrincipalUser(refreshToken);
+
+		return jwtProvider.recreateAccessToken(principalUser);
+	}
+}

--- a/src/main/java/com/najasin/domain/user/service/UserService.java
+++ b/src/main/java/com/najasin/domain/user/service/UserService.java
@@ -13,15 +13,7 @@ import com.najasin.domain.user.entity.Oauth2Entity;
 import com.najasin.domain.user.entity.User;
 import com.najasin.domain.user.repository.UserRepository;
 import com.najasin.global.util.RedisBlackListUtil;
-import com.najasin.security.jwt.exception.JwtBlackListException;
-import com.najasin.security.jwt.exception.JwtExpirationException;
-import com.najasin.security.jwt.exception.JwtNotSupportException;
-import com.najasin.security.jwt.exception.JwtWrongException;
-import com.najasin.security.jwt.exception.JwtWrongSignatureException;
-import com.najasin.security.jwt.util.JwtProvider;
-import com.najasin.security.jwt.util.JwtValidator;
 import com.najasin.security.model.OAuth2Request;
-import com.najasin.security.model.PrincipalUser;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -32,9 +24,6 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final UserTypeRepository userTypeRepository;
 	private final RedisBlackListUtil redisBlackListUtil;
-
-	private final JwtValidator jwtValidator;
-	private final JwtProvider jwtProvider;
 
 	@Transactional
 	public User saveIfNewUser(OAuth2Request request) {
@@ -63,13 +52,6 @@ public class UserService {
 	public void logout(String accessToken, String refreshToken) {
 		redisBlackListUtil.setBlackList(accessToken, "accessToken", 7);
 		redisBlackListUtil.setBlackList(refreshToken, "refreshToken", 7);
-	}
-
-	public String recreateAccessToken(String refreshToken) throws JwtNotSupportException, JwtWrongSignatureException,
-		JwtExpirationException, JwtWrongException, JwtBlackListException {
-		PrincipalUser principalUser = jwtValidator.getPrincipalUser(refreshToken);
-
-		return jwtProvider.recreateAccessToken(principalUser);
 	}
 
 	public String generateUUID() {

--- a/src/main/java/com/najasin/global/advice/AuthControllerAdvice.java
+++ b/src/main/java/com/najasin/global/advice/AuthControllerAdvice.java
@@ -1,0 +1,20 @@
+package com.najasin.global.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.najasin.global.response.ApiResponse;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@RestControllerAdvice("com.najasin.domain.user.AuthController")
+public class AuthControllerAdvice {
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<ApiResponse<?>> entityNotFoundExHandler(EntityNotFoundException exception) {
+		return ResponseEntity
+			.status(HttpStatus.NOT_FOUND)
+			.body(ApiResponse.createFail(exception.getMessage()));
+	}
+}

--- a/src/main/java/com/najasin/global/advice/JwtControllerAdvice.java
+++ b/src/main/java/com/najasin/global/advice/JwtControllerAdvice.java
@@ -12,7 +12,7 @@ import com.najasin.security.jwt.exception.JwtNotSupportException;
 import com.najasin.security.jwt.exception.JwtWrongException;
 import com.najasin.security.jwt.exception.JwtWrongSignatureException;
 
-@RestControllerAdvice(basePackages = {"com.najasin.security.jwt.util"})
+@RestControllerAdvice(basePackages = {"com.najasin.security.jwt.util", "com.najasin.domain.user.AuthController"})
 public class JwtControllerAdvice {
 	@ExceptionHandler(JwtWrongSignatureException.class)
 	public ResponseEntity<ApiResponse<?>> wrongSignatureExHandler(JwtWrongSignatureException exception) {

--- a/src/main/java/com/najasin/security/jwt/util/JwtProvider.java
+++ b/src/main/java/com/najasin/security/jwt/util/JwtProvider.java
@@ -31,6 +31,12 @@ public class JwtProvider {
 		return new JwtToken(accessToken, refreshToken, BEARER_TYPE);
 	}
 
+	public String recreateAccessToken(PrincipalUser principalUser) {
+		Claims claims = getClaims(principalUser);
+
+		return getToken(principalUser, claims, ACCESS_TOKEN_VALIDATION_SECOND);
+	}
+
 	public Claims getClaims(PrincipalUser principalUser) {
 		Claims claims = Jwts.claims();
 		claims.put("id", principalUser.getName());

--- a/src/main/java/com/najasin/security/jwt/util/JwtValidator.java
+++ b/src/main/java/com/najasin/security/jwt/util/JwtValidator.java
@@ -45,6 +45,17 @@ public class JwtValidator {
 		return new UsernamePasswordAuthenticationToken(principalUser, "", principalUser.getAuthorities());
 	}
 
+	public PrincipalUser getPrincipalUser(String token) throws
+		JwtNotSupportException,
+		JwtWrongSignatureException,
+		JwtExpirationException,
+		JwtWrongException,
+		JwtBlackListException {
+		Claims claims = getTokenClaims(token);
+		User user = userService.findById(claims.get("id", String.class));
+		return principalUserMapper.toPrincipalUser(user);
+	}
+
 	private Claims getTokenClaims(String token) throws
 		JwtWrongSignatureException,
 		JwtExpirationException,

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     open-in-view: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
   security:
     oauth2:


### PR DESCRIPTION
> ### PR Introduce

- #71 

> ### Description

Refresh Token을 통한 Access Token 재발급 로직을 구현한다.

> ### Core Features

```java
. . .
	public String recreateAccessToken(String refreshToken) throws JwtNotSupportException, JwtWrongSignatureException,
		JwtExpirationException, JwtWrongException, JwtBlackListException {
		PrincipalUser principalUser = jwtValidator.getPrincipalUser(refreshToken);

		return jwtProvider.recreateAccessToken(principalUser);
	}
. . .
```


> ### etc
